### PR TITLE
fix: use @typescript-eslint/no-shadow for typescript files

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -19,6 +19,8 @@ module.exports = {
         // Modified recommended rules (to match AirBnB rules)
         '@typescript-eslint/indent': ['error', 2],
         indent: 'off',
+        'no-shadow': 0,
+        '@typescript-eslint/no-shadow': 1,
       },
     },
     {


### PR DESCRIPTION
This PR addresses issues with typescript enums and the no-shadow rule.

Issue (see https://github.com/MarkusWendorf/quality-gate-ts-enums-no-shadow):

```typescript
// 'Direction' is already declared in the upper scope on line 1 column 6 eslint[no-shadow]
enum Direction {
  Up,
  Down,
  Left,
  Right,
}
```

This PR disables the eslint "no-shadow" rule for typescript files and enables the corresponding typescript-eslint rule "@typescript-eslint/no-shadow". As is suggested by the typescript-eslint docs: https://typescript-eslint.io/rules/no-shadow/.

You can test this PR by installing "npm install MarkusWendorf/quality-gate#main" into the reproduction repo above.